### PR TITLE
Add support for mapping into Keyword instead of Map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ is being returned.
     'l' stands for (l)ist. This forces `xpath/2` to return a list. Without
     `l`, `xpath/2` will only return the first element of the match
 
+  * `~x"//some/path"k`
+  
+     'k' stands for (K)eyword. This forces `xpath/2` to return a Keyword instead of a Map.
+     
   * `~x"//some/path"el` - mix of the above
 
   * `~x"//some/path"s`

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -24,13 +24,14 @@ defmodule SweetXmlTest do
   end
 
   test "xpath sigil" do
-    assert ~x"//header/text()" == %SweetXpath{path: '//header/text()', is_value: true, is_string: false, is_list: false}
-    assert ~x"//header/text()"e == %SweetXpath{path: '//header/text()', is_value: false, is_string: false, is_list: false}
-    assert ~x"//header/text()"l == %SweetXpath{path: '//header/text()', is_value: true, is_string: false, is_list: true}
-    assert ~x"//header/text()"el == %SweetXpath{path: '//header/text()', is_value: false, is_string: false, is_list: true}
-    assert ~x"//header/text()"le == %SweetXpath{path: '//header/text()', is_value: false, is_string: false, is_list: true}
-    assert ~x"//header/text()"sl == %SweetXpath{path: '//header/text()', is_value: true, is_string: true, is_list: true}
-    assert ~x"//header/text()"ls == %SweetXpath{path: '//header/text()', is_value: true, is_string: true, is_list: true}
+    assert ~x"//header/text()" == %SweetXpath{path: '//header/text()', is_value: true, is_string: false, is_list: false, is_keyword: false}
+    assert ~x"//header/text()"e == %SweetXpath{path: '//header/text()', is_value: false, is_string: false, is_list: false, is_keyword: false}
+    assert ~x"//header/text()"l == %SweetXpath{path: '//header/text()', is_value: true, is_string: false, is_list: true, is_keyword: false}
+    assert ~x"//header/text()"k == %SweetXpath{path: '//header/text()', is_value: true, is_string: false, is_list: false, is_keyword: true}
+    assert ~x"//header/text()"el == %SweetXpath{path: '//header/text()', is_value: false, is_string: false, is_list: true, is_keyword: false}
+    assert ~x"//header/text()"le == %SweetXpath{path: '//header/text()', is_value: false, is_string: false, is_list: true, is_keyword: false}
+    assert ~x"//header/text()"sl == %SweetXpath{path: '//header/text()', is_value: true, is_string: true, is_list: true, is_keyword: false}
+    assert ~x"//header/text()"ls == %SweetXpath{path: '//header/text()', is_value: true, is_string: true, is_list: true, is_keyword: false}
   end
 
   test "xpath with sweet_xpath as only argment", %{simple: doc} do
@@ -318,6 +319,21 @@ defmodule SweetXmlTest do
       %{name: 'Match One', winner: %{name: 'Team One'}},
       %{name: 'Match Two', winner: %{name: 'Team Two'}},
       %{name: 'Match Three', winner: %{name: 'Team One'}}
+    ]
+
+    # get a list of matchups with keyword structure preserving order defined in spec
+    result = readme |> xpath(
+      ~x"//matchups/matchup"lk,
+      name: ~x"./name/text()",
+      winner: [
+        ~x".//team/id[.=ancestor::matchup/@winner-id]/..",
+        name: ~x"./name/text()"
+      ]
+    )
+    assert result == [
+      [name: 'Match One', winner: %{name: 'Team One'}],
+      [name: 'Match Two', winner: %{name: 'Team Two'}],
+      [name: 'Match Three', winner: %{name: 'Team One'}]
     ]
 
     # get a map with lots of nesting


### PR DESCRIPTION
Map in elixir does not preserve ordering unlike Hash in ruby. Luckily, Keyword in elixir does.

Preserving ordering of key/value pairs according to the spec is very useful. It makes things DRY when setting up formatting of final output.

Map will still be the default container for lookup performance, but add the sigil_x modifier k for mapping into Keywords. xmap/2 updated to output Keyword when desired.

e.g. `~x"<xpath>"k`

```
iex> import SweetXml
iex> doc = "<body><header><p>Message</p><ul><li>One</li><li><a>Two</a></li></ul></header></body>"
iex> doc
...> |> xmap(
...>      message: ~x"//p/text()",
...>      ul: [
...>        ~x"//ul"k,
...>        first_name: ~x"./li/first_name/text()",
...>        last_name: ~x"./li/last_name/text()"
...>      ]
...>    )
%{message: 'Message', ul: [first_name: 'John', last_name: 'Doe']}
```
