### PR TITLE
Add a 'o' modifier to the ~x sigil allowing a path to not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,19 @@ is being returned.
     `l`, `xpath/2` will only return the first element of the match
 
   * `~x"//some/path"k`
-  
+
      'k' stands for (K)eyword. This forces `xpath/2` to return a Keyword instead of a Map.
-     
+
   * `~x"//some/path"el` - mix of the above
 
   * `~x"//some/path"s`
 
     's' stands for (s)tring. This forces `xpath/2` to return the value as
     string instead of a char list.
+
+  * `x"//some/path"o`
+
+    'o' stands for (O)ptional. This allows the path to not exist, and will return nil.
 
   * `~x"//some/path"sl` - string list.
 

--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -416,7 +416,7 @@ defmodule SweetXml do
   def xpath(parent, sweet_xpath, subspec) do
     if sweet_xpath.is_list do
       current_entities = xpath(parent, sweet_xpath)
-      Enum.map(current_entities, fn (entity) -> xmap(entity, subspec, sweet_xpath.is_keyword) end)
+      Enum.map(current_entities, fn (entity) -> xmap(entity, subspec, sweet_xpath) end)
     else
       current_entity = xpath(parent, sweet_xpath)
       xmap(current_entity, subspec, sweet_xpath)

--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -1,5 +1,5 @@
 defmodule SweetXpath do
-  defstruct path: ".", is_value: true, is_string: false, is_list: false, is_keyword: false
+  defstruct path: ".", is_value: true, is_string: false, is_list: false, is_keyword: false, is_optional: false
 end
 
 defmodule SweetXml do
@@ -83,6 +83,10 @@ defmodule SweetXml do
       's' stands for (s)tring. This forces `xpath/2` to return the value as
       string instead of a char list.
 
+    * `x"//some/path"o`
+
+      'o' stands for (O)ptional. This allows the path to not exist, and will return nil.
+
     * `~x"//some/path"sl` - string list.
 
   Notice also in the examples section, we always import SweetXml first. This
@@ -151,6 +155,10 @@ defmodule SweetXml do
       's' stands for (s)tring. This forces `xpath/2` to return the value as
       string instead of a char list.
 
+    * `x"//some/path"o`
+
+      'o' stands for (O)ptional. This allows the path to not exist, and will return nil.
+
     * `~x"//some/path"sl` - string list.
   """
   def sigil_x(path, modifiers \\ '') do
@@ -159,7 +167,8 @@ defmodule SweetXml do
       is_value: not ?e in modifiers,
       is_string: ?s in modifiers,
       is_list: ?l in modifiers,
-      is_keyword: ?k in modifiers
+      is_keyword: ?k in modifiers,
+      is_optional: ?o in modifiers
     }
   end
 
@@ -410,7 +419,7 @@ defmodule SweetXml do
       Enum.map(current_entities, fn (entity) -> xmap(entity, subspec, sweet_xpath.is_keyword) end)
     else
       current_entity = xpath(parent, sweet_xpath)
-      xmap(current_entity, subspec, sweet_xpath.is_keyword)
+      xmap(current_entity, subspec, sweet_xpath)
     end
   end
 
@@ -468,11 +477,15 @@ defmodule SweetXml do
       ...>    ], true)
       [message: 'Message', ul: %{a: 'Two'}]
   """
-  def xmap(parent, mapping), do: xmap(parent, mapping, false)
+  def xmap(parent, mapping), do: xmap(parent, mapping, %{is_keyword: false})
 
-  def xmap(_, [], _is_keyword = false), do: %{}
+  def xmap(nil, _, %{is_optional: true}), do: nil
 
-  def xmap(_, [], _is_keyword = true), do: []
+  def xmap(parent, [], atom) when is_atom(atom), do: xmap(parent, [], %{is_keyword: atom})
+
+  def xmap(_, [], %{is_keyword: false}), do: %{}
+
+  def xmap(_, [], %{is_keyword: true}), do: []
 
   def xmap(parent, [{label, spec} | tail], is_keyword) when is_list(spec) do
     [sweet_xpath | subspec] = spec

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -393,4 +393,13 @@ defmodule SweetXmlTest do
 
     assert result == false
   end
+
+  test "xpath with route that doesn't exist", %{simple: simple} do
+    assert xpath(simple, ~x"//ListBucketResult"o,
+        name: ~x"./Name/text()"s,
+        is_truncated: ~x"./IsTruncated/text()"s,
+        owner: [
+            ~x"./Owner",
+            id: ~x"./ID/text()"s]) == nil
+  end
 end


### PR DESCRIPTION
Motivation:

I'm the author if ExAws, a set of elixir clients for interacting with AWS, and have been using sweet_xml to parse the resulting xml. This has been an extremely helpful library for handling xml results returned by AWS.

However, as it turns out, AWS will often leave out portions of xml depending on permissions, request parameters, and so on. Presently this will return the following error:

```
     ** (Protocol.UndefinedError) protocol Enumerable not implemented for nil
     stacktrace:
       (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
       (elixir) lib/enum.ex:112: Enumerable.reduce/3
       (elixir) lib/stream.ex:695: Stream.do_enum_transform/8
       (elixir) lib/stream.ex:647: Stream.do_transform/7
       (sweet_xml) lib/sweet_xml.ex:513: anonymous fn/4 in SweetXml.continuation_opts/2
       xmerl_scan.erl:563: :xmerl_scan.scan_document/2
       xmerl_scan.erl:286: :xmerl_scan.string/2
       (sweet_xml) lib/sweet_xml.ex:189: SweetXml.parse/2
```

What this PR does is add an 'o' modifier `~x"//some/bad/path"o` such that it will return nil if the path does not exist instead of exploding.