### PR TITLE
Add Travis CI build and status badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: elixir
+elixir:
+  - 1.0.2
+sudo: false
+script: mix test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-SweetXml
-========
+# SweetXml [![Build Status](https://api.travis-ci.org/awetzel/sweet_xml.svg)][Continuous Integration]
+
+[Continuous Integration]: http://travis-ci.org/awetzel/sweet_xml "Build status by Travis-CI"
 
 `SweetXml` is a thin wrapper around `:xmerl`. It allows you to converts a
 `string` or `xmlElement` record as defined in `:xmerl` to an elixir value such


### PR DESCRIPTION
I like this xmerl wrapper more the the others which are available for Elixir.

The Travis URLs point to `awetzel/sweet_xml`, so builds would need to be activated under https://travis-ci.org/awetzel