### PR TITLE
Relax Elixir version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule SweetXml.Mixfile do
     [
       app: :sweet_xml,
       version: "0.4.0",
-      elixir: "~> 1.0.0",
+      elixir: "~> 1.0",
       deps: deps,
       package: [
         contributors: ["Frank Liu", "Arnaud Wetzel", "Tomáš Brukner", "Vinícius Sales", "Sean Tan"],


### PR DESCRIPTION
Since Elixir 1.1 is now out, specifying `elixir: "~> 1.0.0"` in your Mixfile
will yield a warning for anyone depending on sweet_xml running on Elixir 1.1 or
later.

Elixir versioning follows semantic versioning, so the only effect of this change
will be to eliminate some compile warnings.