### PR TITLE
Add an 'i' modifier to the ~x sigil allowing casting to integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 SweetXml
 ========
 
-`SweetXml` is a thin wrapper around `:xmerl`. It allows you to converts a
-`string` or `xmlElement` record as defined in `:xmerl` to an elixir value such
-as `map`, `list`, `char_list`, or any combination of these.
+`SweetXml` is a thin wrapper around `:xmerl`. It allows you to convert a
+`char_list` or `xmlElement` record as defined in `:xmerl` to an elixir value such
+as `map`, `list`, `string`, `integer`, or any combination of these.
 
 
 ## Examples
@@ -172,12 +172,19 @@ is being returned.
 
   * `~x"//some/path"sl` - string list.
 
+  * `~x"//some/path"i`
+
+    'i' stands for (i)nteger. This forces `xpath/2` to return the value as
+    integer instead of a char list.
+
+  * `~x"//some/path"il` - integer list.
+
 Also in the examples section, we always import SweetXml first. This
 makes `x_sigil` available in the current scope. Without it, instead of using
 `~x`, you can use the `%SweetXpath` struct
 
 ```elixir
-assert ~x"//some/path"e == %SweetXpath{path: '//some/path', is_value: false, is_string: false, is_list: false}
+assert ~x"//some/path"e == %SweetXpath{path: '//some/path', is_value: false, is_list: false, cast_to: false}
 ```
 
 Note the use of char_list in the path definition.

--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -1,5 +1,5 @@
 defmodule SweetXpath do
-  defstruct path: ".", is_value: true, is_string: false, is_list: false, is_keyword: false
+  defstruct path: ".", is_value: true, is_list: false, is_keyword: false, cast_to: false
 end
 
 defmodule SweetXml do
@@ -90,7 +90,7 @@ defmodule SweetXml do
   `~x`, you can do the following
 
       iex> doc = "<h1><a>Some linked title</a></h1>"
-      iex> doc |> SweetXml.xpath(%SweetXpath{path: '//a/text()', is_value: true, is_string: false, is_list: false, is_keyword: false})
+      iex> doc |> SweetXml.xpath(%SweetXpath{path: '//a/text()', is_value: true, cast_to: false, is_list: false, is_keyword: false})
       'Some linked title'
 
   Note the use of char_list in the path definition.
@@ -114,13 +114,13 @@ defmodule SweetXml do
   boolean fields
 
       iex> SweetXml.sigil_x("//some/path", 'e')
-      %SweetXpath{path: '//some/path', is_value: false, is_string: false, is_list: false, is_keyword: false}
+      %SweetXpath{path: '//some/path', is_value: false, cast_to: false, is_list: false, is_keyword: false}
 
   or you can simply import and use the `~x` expression
 
       iex> import SweetXml
       iex> ~x"//some/path"e
-      %SweetXpath{path: '//some/path', is_value: false, is_string: false, is_list: false, is_keyword: false}
+      %SweetXpath{path: '//some/path', is_value: false, cast_to: false, is_list: false, is_keyword: false}
 
   Valid modifiers are `e`, `s`, `l` and `k`. Below is the full explanation
 
@@ -152,14 +152,25 @@ defmodule SweetXml do
       string instead of a char list.
 
     * `~x"//some/path"sl` - string list.
+
+    * `~x"//some/path"i`
+
+      'i' stands for (i)nteger. This forces `xpath/2` to return the value as
+      integer instead of a char list.
+
+    * `~x"//some/path"il` - integer list
   """
   def sigil_x(path, modifiers \\ '') do
     %SweetXpath{
       path: String.to_char_list(path),
       is_value: not ?e in modifiers,
-      is_string: ?s in modifiers,
       is_list: ?l in modifiers,
-      is_keyword: ?k in modifiers
+      is_keyword: ?k in modifiers,
+      cast_to: cond do
+        ?s in modifiers -> :string
+        ?i in modifiers -> :integer
+        :otherwise -> false
+      end
     }
   end
 
@@ -373,24 +384,16 @@ defmodule SweetXml do
     parent |> parse |> xpath(spec)
   end
 
-  def xpath(parent, %SweetXpath{is_list: true, is_value: true, is_string: true} = spec) do
-    get_current_entities(parent, spec) |> Enum.map &(_value(&1) |> to_string)
-  end
-
-  def xpath(parent, %SweetXpath{is_list: true, is_value: true, is_string: false} = spec) do
-    get_current_entities(parent, spec) |> Enum.map &(_value(&1))
+  def xpath(parent, %SweetXpath{is_list: true, is_value: true, cast_to: cast} = spec) do
+    get_current_entities(parent, spec) |> Enum.map &(_value(&1) |> to_cast(cast))
   end
 
   def xpath(parent, %SweetXpath{is_list: true, is_value: false} = spec) do
     get_current_entities(parent, spec)
   end
 
-  def xpath(parent, %SweetXpath{is_list: false, is_value: true, is_string: true} = spec) do
-    get_current_entities(parent, spec) |> _value |> to_string
-  end
-
-  def xpath(parent, %SweetXpath{is_list: false, is_value: true, is_string: false} = spec) do
-    get_current_entities(parent, spec) |> _value
+  def xpath(parent, %SweetXpath{is_list: false, is_value: true, cast_to: cast} = spec) do
+    get_current_entities(parent, spec) |> _value |> to_cast(cast)
   end
 
   def xpath(parent, %SweetXpath{is_list: false, is_value: false} = spec) do
@@ -581,5 +584,9 @@ defmodule SweetXml do
       List.first(ret)
     end
   end
+
+  defp to_cast(value, false), do: value
+  defp to_cast(value, :string), do: to_string(value)
+  defp to_cast(value, :integer), do: String.to_integer(to_string(value))
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule SweetXml.Mixfile do
     [
       app: :sweet_xml,
       version: "0.4.0",
-      elixir: "~> 1.0.0",
+      elixir: "~> 1.0",
       deps: deps,
       package: [
         contributors: ["Frank Liu", "Arnaud Wetzel", "Tomáš Brukner", "Vinícius Sales", "Sean Tan"],

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -24,14 +24,18 @@ defmodule SweetXmlTest do
   end
 
   test "xpath sigil" do
-    assert ~x"//header/text()" == %SweetXpath{path: '//header/text()', is_value: true, is_string: false, is_list: false, is_keyword: false}
-    assert ~x"//header/text()"e == %SweetXpath{path: '//header/text()', is_value: false, is_string: false, is_list: false, is_keyword: false}
-    assert ~x"//header/text()"l == %SweetXpath{path: '//header/text()', is_value: true, is_string: false, is_list: true, is_keyword: false}
-    assert ~x"//header/text()"k == %SweetXpath{path: '//header/text()', is_value: true, is_string: false, is_list: false, is_keyword: true}
-    assert ~x"//header/text()"el == %SweetXpath{path: '//header/text()', is_value: false, is_string: false, is_list: true, is_keyword: false}
-    assert ~x"//header/text()"le == %SweetXpath{path: '//header/text()', is_value: false, is_string: false, is_list: true, is_keyword: false}
-    assert ~x"//header/text()"sl == %SweetXpath{path: '//header/text()', is_value: true, is_string: true, is_list: true, is_keyword: false}
-    assert ~x"//header/text()"ls == %SweetXpath{path: '//header/text()', is_value: true, is_string: true, is_list: true, is_keyword: false}
+    assert ~x"//header/text()" == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: false}
+    assert ~x"//header/text()"e == %SweetXpath{path: '//header/text()', is_value: false, is_list: false, is_keyword: false, cast_to: false}
+    assert ~x"//header/text()"l == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: false}
+    assert ~x"//header/text()"k == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: true, cast_to: false}
+    assert ~x"//header/text()"s == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: :string}
+    assert ~x"//header/text()"i == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: :integer}
+    assert ~x"//header/text()"el == %SweetXpath{path: '//header/text()', is_value: false, is_list: true, is_keyword: false, cast_to: false}
+    assert ~x"//header/text()"le == %SweetXpath{path: '//header/text()', is_value: false, is_list: true, is_keyword: false, cast_to: false}
+    assert ~x"//header/text()"sl == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: :string}
+    assert ~x"//header/text()"ls == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: :string}
+    assert ~x"//header/text()"il == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: :integer}
+    assert ~x"//header/text()"li == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: :integer}
   end
 
   test "xpath with sweet_xpath as only argment", %{simple: doc} do
@@ -392,5 +396,11 @@ defmodule SweetXmlTest do
     result = simple |> xpath(~x"false()")
 
     assert result == false
+  end
+
+  test "casting", %{complex: doc} do
+    assert xpath(doc, ~x[/fantasy_content/league/league_id/text()])  == '239541'
+    assert xpath(doc, ~x[/fantasy_content/league/league_id/text()]s) == "239541"
+    assert xpath(doc, ~x[/fantasy_content/league/league_id/text()]i) ==  239541
   end
 end


### PR DESCRIPTION
This pull request adds `i` modifier for `~x` sigil, which casts return values into integers.

Documentation was updated, new tests were added - all are green.

### Additional changes

`is_string` attribute in `%SweetXml{}` struct was changed into more generic `cast_to`. It's possible values:
- `cast_to: false` - is old `to_string: false`
- `cast_to: :string` - is old `to_string: true`
- `cast_to: :integer` - would be new `to_string: false, to_integer: true`

`xpath/2` big if/else tree was reworked into smaller, pattern-matched functions.