### PR TITLE
Add exrm support in building erlang release.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule SweetXml.Mixfile do
   end
 
   def application do
-    []
+    [applications: [:xmerl]]
   end
 
   defp deps do


### PR DESCRIPTION
There is a need to explicitly add :xmerl in the mix.exs file for exrm to pick it up and include xmerl in compilation for erlang release. If not, application release generated using sweet_xml will throw runtime exception with undef xmerl functions.