### PR TITLE
Fix xml entities splitting strings

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -401,6 +401,13 @@ defmodule SweetXml do
     get_current_entities(parent, spec)
   end
 
+  def xpath(parent, %SweetXpath{is_list: false, is_value: true, cast_to: :string} = spec) do
+    spec = %SweetXpath{spec | is_list: true}
+    get_current_entities(parent, spec)
+    |> Enum.map(&(_value(&1) |> to_cast(:string)))
+    |> Enum.join
+  end
+
   def xpath(parent, %SweetXpath{is_list: false, is_value: true, cast_to: cast} = spec) do
     get_current_entities(parent, spec) |> _value |> to_cast(cast)
   end

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -412,4 +412,8 @@ defmodule SweetXmlTest do
     assert xpath(doc, ~x[/fantasy_content/league/league_id/text()]s) == "239541"
     assert xpath(doc, ~x[/fantasy_content/league/league_id/text()]i) ==  239541
   end
+
+  test "xml entities do not split strings" do
+    assert xpath("<foo>hello&amp;world</foo>", ~x[/foo/text()]s) == "hello&world"
+  end
 end


### PR DESCRIPTION
For some reason, `xmerl_scan:string/2` breaks text like `hello&amp;world` up into two text nodes. This simply joins all text nodes together, which is what I expect when using `~x'.../text()'s`