### PR TITLE
[Bugfix] Ensure get_current_entities/2 returns a list when needed.

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -599,7 +599,7 @@ defmodule SweetXml do
   end
 
   defp get_current_entities(parent, %SweetXpath{path: path, is_list: true}) do
-    :xmerl_xpath.string(path, parent)
+    :xmerl_xpath.string(path, parent) |> List.wrap
   end
 
   defp get_current_entities(parent, %SweetXpath{path: path, is_list: false}) do

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -417,5 +417,6 @@ defmodule SweetXmlTest do
 
   test "xml entities do not split strings" do
     assert xpath("<foo>hello&amp;world</foo>", ~x[/foo/text()]s) == "hello&world"
+    assert xpath("<foo>hello&amp;world</foo>", ~x"name(.)"s) == "foo"
   end
 end


### PR DESCRIPTION
Currently the following is broken because get_current_entities/2 does not always return a list.

```elixir
assert xpath("<foo>hello&amp;world</foo>", ~x"name(.)"s) == "foo"
```
it throws
```
     ** (Protocol.UndefinedError) protocol Enumerable not implemented for {:xmlObj, :string, 'foo'}
     stacktrace:
       (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
       (elixir) lib/enum.ex:116: Enumerable.reduce/3
       (elixir) lib/enum.ex:1486: Enum.reduce/3
       (elixir) lib/enum.ex:1092: Enum.map/2
       (sweet_xml) lib/sweet_xml.ex:413: SweetXml.xpath/2
```

With the fix, `get_current_entities/2` will always return a list when `%SweetXpath{is_list: true}`.
