### PR TITLE
Namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,68 @@ assert ~x"//some/path"e == %SweetXpath{path: '//some/path', is_value: false, is_
 
 Note the use of char_list in the path definition.
 
+## Namespace support
+
+Given a xml document such as below
+
+```xml
+<?xml version="1.05" encoding="UTF-8"?>
+<game xmlns="http://example.com/fantasy-league" xmlns:ns1="http://example.com/baseball-stats">
+  <matchups>
+    <matchup winner-id="1">
+      <name>Match One</name>
+      <teams>
+        <team>
+          <id>1</id>
+          <name>Team One</name>
+          <ns1:runs>5</ns1:runs>
+        </team>
+        <team>
+          <id>2</id>
+          <name>Team Two</name>
+          <ns1:runs>2</ns1:runs>
+        </team>
+      </teams>
+    </matchup>
+  </matchups>
+</game>
+```
+
+We can do the following
+
+```elixir
+import SweetXml
+xml_str = "..." # as above
+doc = parse(xml_str, namespace_conformant: true)
+```
+
+Note the fact that we explicitly parse the XML with the `namespace_conformant:
+true` option. This is needed to allow nodes to be identified in a prefix
+independent way.
+
+We can use namespace prefixes of our preference, regardless of what prefix is
+used in the document:
+
+```elixir
+result = doc
+  |> xpath(~x"//ff:matchup/ff:name/text()"
+           |> add_namespace("ff", "http://example.com/fantasy-league"))
+
+assert result == 'Match One'
+```
+
+We can specify multiple namespace prefixes: 
+
+```elixir
+result = doc
+  |> xpath(~x"//ff:matchup//bb:runs/text()"
+           |> add_namespace("ff", "http://example.com/fantasy-league")
+           |> add_namespace("bb", "http://example.com/baseball-stats"))
+
+assert result == '5'
+```
+
+
 ## From Chaining to Nesting
 
 Here's a brief explanation to how nesting came about.

--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -6,7 +6,14 @@ defmodule SweetXpath do
     def self_val(val), do: val
   end
 
-  defstruct path: ".", is_value: true, is_list: false, is_keyword: false, is_optional: false, cast_to: false, transform_fun: &Priv.self_val/1
+  defstruct path: ".",
+    is_value: true,
+    is_list: false,
+    is_keyword: false,
+    is_optional: false,
+    cast_to: false,
+    transform_fun: &(Priv.self_val/1),
+    namespaces: []
 end
 
 defmodule SweetXml do
@@ -196,7 +203,12 @@ defmodule SweetXml do
     }
   end
 
-  @doc """
+  def add_namespace(xpath, prefix, uri) do
+    %SweetXpath{xpath | namespaces: [{to_char_list(prefix), to_char_list(uri)}
+                                     | xpath.namespaces]}
+  end
+
+@doc """
   `doc` can be
 
   - a byte list (iodata)
@@ -629,12 +641,12 @@ defmodule SweetXml do
     end
   end
 
-  defp get_current_entities(parent, %SweetXpath{path: path, is_list: true}) do
-    :xmerl_xpath.string(path, parent) |> List.wrap
+  defp get_current_entities(parent, %SweetXpath{path: path, is_list: true, namespaces: namespaces}) do
+    :xmerl_xpath.string(path, parent, [namespace: namespaces]) |> List.wrap
   end
 
-  defp get_current_entities(parent, %SweetXpath{path: path, is_list: false}) do
-    ret = :xmerl_xpath.string(path, parent)
+  defp get_current_entities(parent, %SweetXpath{path: path, is_list: false, namespaces: namespaces}) do
+    ret = :xmerl_xpath.string(path, parent, [namespace: namespaces])
     if is_record?(ret, :xmlObj) do
       ret
     else

--- a/test/files/namespaces.xml
+++ b/test/files/namespaces.xml
@@ -1,0 +1,6 @@
+<?xml version="1.05" encoding="UTF-8"?>
+<thing xmlns="http://example.com/thing" xmlns:ns1="http://example.com/special">
+  <id>42</id>
+  <size>large</size>
+  <ns1:delivery_type>courier</ns1:delivery_type>
+</thing>

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -10,7 +10,13 @@ defmodule SweetXmlTest do
     complex_stream = File.stream!("./test/files/complex.xml")
     simple_stream = File.stream!("./test/files/simple_stream.xml")
     readme = File.read!("test/files/readme.xml")
-    {:ok, [simple: simple, complex: complex, readme: readme, complex_stream: complex_stream, simple_stream: simple_stream]}
+    namespaces = File.read!("test/files/namespaces.xml")
+    {:ok, [simple: simple,
+           complex: complex,
+           readme: readme,
+           complex_stream: complex_stream,
+           simple_stream: simple_stream,
+           namespaces: namespaces]}
   end
 
   test "parse", %{simple: doc} do
@@ -446,5 +452,20 @@ defmodule SweetXmlTest do
     )
 
     assert result == %{iso_week: 36, scoreboard: %{week: 16, matchups: 4}}
+  end
+
+  test "namespace support: same prefix as in document", %{namespaces: doc} do
+    result = doc |> xpath(~x"//ns1:delivery_type/text()"s)
+    assert result == "courier"
+  end
+
+  test "namespace support: alternate prefixes", %{namespaces: doc} do
+    result =
+      parse(doc, namespace_conformant: true)
+      |> xpath(~x"/t:thing/s:delivery_type/text()"s
+               |> add_namespace("s", "http://example.com/special")
+               |> add_namespace("t", "http://example.com/thing"))
+
+    assert result == "courier"
   end
 end


### PR DESCRIPTION
Adds the capability to use arbitrary namespace prefixes in xpaths.  For example:

```elixir
doc
  |> xpath(~x"//ff:matchup/ff:name/text()"
           |> add_namespace("ff", "http://example.com/fantasy-league"))
```

This is really useful when consuming XML from multiple sources that don't all use the same namespace prefixes.