### PR TITLE
Add cast modifier for boolean values

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -198,6 +198,7 @@ defmodule SweetXml do
         ?s in modifiers -> :string
         ?i in modifiers -> :integer
         ?f in modifiers -> :float
+        ?b in modifiers -> :boolean
         :otherwise -> false
       end
     }
@@ -658,5 +659,7 @@ defmodule SweetXml do
   defp to_cast(value, :string), do: to_string(value)
   defp to_cast(value, :integer), do: String.to_integer(to_string(value))
   defp to_cast(value, :float), do: String.to_float(to_string(value))
+  defp to_cast('true', :boolean), do: true
+  defp to_cast('false', :boolean), do: false
 
 end

--- a/test/files/complex.xml
+++ b/test/files/complex.xml
@@ -7,6 +7,7 @@
     <url>http://football.fantasysports.yahoo.com/archive/nfl/2012/239541</url>
     <draft_status>postdraft</draft_status>
     <num_teams>10</num_teams>
+    <active>true</active>
     <edit_key>17</edit_key>
     <weekly_deadline/>
     <league_update_timestamp>1357339553</league_update_timestamp>

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -30,19 +30,22 @@ defmodule SweetXmlTest do
   end
 
   test "xpath sigil" do
-    assert ~x"//header/text()" == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: false}
-    assert ~x"//header/text()"e == %SweetXpath{path: '//header/text()', is_value: false, is_list: false, is_keyword: false, cast_to: false}
-    assert ~x"//header/text()"l == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: false}
-    assert ~x"//header/text()"k == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: true, cast_to: false}
-    assert ~x"//header/text()"s == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: :string}
-    assert ~x"//header/text()"i == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: :integer}
-    assert ~x"//header/text()"f == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: :float}
+    assert ~x"//header/text()"   == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: false}
+    assert ~x"//header/text()"e  == %SweetXpath{path: '//header/text()', is_value: false, is_list: false, is_keyword: false, cast_to: false}
+    assert ~x"//header/text()"l  == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: false}
+    assert ~x"//header/text()"k  == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: true, cast_to: false}
+    assert ~x"//header/text()"s  == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: :string}
+    assert ~x"//header/text()"i  == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: :integer}
+    assert ~x"//header/text()"f  == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: :float}
     assert ~x"//header/text()"el == %SweetXpath{path: '//header/text()', is_value: false, is_list: true, is_keyword: false, cast_to: false}
     assert ~x"//header/text()"le == %SweetXpath{path: '//header/text()', is_value: false, is_list: true, is_keyword: false, cast_to: false}
     assert ~x"//header/text()"sl == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: :string}
     assert ~x"//header/text()"ls == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: :string}
     assert ~x"//header/text()"il == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: :integer}
     assert ~x"//header/text()"li == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: :integer}
+    assert ~x"//header/text()"b  == %SweetXpath{path: '//header/text()', is_value: true, is_list: false, is_keyword: false, cast_to: :boolean}
+    assert ~x"//header/text()"bl == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: :boolean}
+    assert ~x"//header/text()"lb == %SweetXpath{path: '//header/text()', is_value: true, is_list: true, is_keyword: false, cast_to: :boolean}
   end
 
   test "xpath with sweet_xpath as only argment", %{simple: doc} do
@@ -418,7 +421,8 @@ defmodule SweetXmlTest do
     assert xpath(doc, ~x[/fantasy_content/league/league_id/text()])  == '239541'
     assert xpath(doc, ~x[/fantasy_content/league/league_id/text()]s) == "239541"
     assert xpath(doc, ~x[/fantasy_content/league/league_id/text()]i) ==  239541
-    assert xpath(doc, ~x[//total/text()]f) ==  204.68
+    assert xpath(doc, ~x[//total/text()]f) == 204.68
+    assert xpath(doc, ~x[//active/text()]b) == true
   end
 
   test "xml entities do not split strings" do


### PR DESCRIPTION
Hi there! Thank you for making `sweet_xml`, it works *amazingly* well. 😀 

While parsing an XML with some boolean values, I realised that boolean values are actually standardised in the [XML Schema specification](https://www.w3.org/TR/xmlschema-2/#boolean), with values `true` and `false` (and non-canonically `0` and `1`). 

I think having a `b` modifier for the `~x` sigil would be a nice addition! I have included a test case for casting with `b`, and checking for the sigil with `b`, `bl`, and `lb`

Please let me know what you think, and if I need to make any additional changes! 

Thanks again! 👋 